### PR TITLE
Add plugin.toml, cleanup spacing in help

### DIFF
--- a/commands
+++ b/commands
@@ -103,16 +103,16 @@ EOF
 
 print_help(){
   cat<<EOF
-    hostkeys                                        Print an explanation (Useful to get the concept)
-    hostkeys:shared:show                            Show shared hostkeys
-    hostkeys:shared:add                             Add a shared hostkey
-    hostkeys:shared:delete                          Deletes all shared hostkeys
-    hostkeys:shared:delete <hostname>               Deletes the shared hostkeys for the given host
-    hostkeys:shared:autoadd <hostname>              Automatically add hostkeys for a given host to the shared hostkeys
-    hostkeys:app:show <app>                         Show all hostkeys for a given app
-    hostkeys:app:add <app>                          Add a app-specific hostkey
-    hostkeys:app:delete <app>                       Deletes all app-specific hostkeys
-    hostkeys:app:autoadd <app> <hostname>           Automatically add hostkeys for a given host to the shared hostkeys
+    hostkeys, Print an explanation (Useful to get the concept)
+    hostkeys:shared:show, Show shared hostkeys
+    hostkeys:shared:add, Add a shared hostkey
+    hostkeys:shared:delete, Deletes all shared hostkeys
+    hostkeys:shared:delete <hostname>, Deletes the shared hostkeys for the given host
+    hostkeys:shared:autoadd <hostname>, Automatically add hostkeys for a given host to the shared hostkeys
+    hostkeys:app:show <app>, Show all hostkeys for a given app
+    hostkeys:app:add <app>, Add a app-specific hostkey
+    hostkeys:app:delete <app>, Deletes all app-specific hostkeys
+    hostkeys:app:autoadd <app> <hostname>, Automatically add hostkeys for a given host to the shared hostkeys
 EOF
   return
 }

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+name = "dokku-hostkeys-plugin"
+description = "Manage hostkeys (for .ssh/known_hosts) to your container environment"
+version = "0.1.0"
+website_url = "https://github.com/expa/dokku-hostkeys-plugin"
+[plugin.config]


### PR DESCRIPTION
Add plugin.toml for dokku 0.4.0 plugn compatibility
Replace hard white spaces with ', ' for help